### PR TITLE
Change default for braille in epub enhancement to false.

### DIFF
--- a/modules/scripts/epub3-to-epub3/src/main/resources/xml/epub3-to-epub3.xpl
+++ b/modules/scripts/epub3-to-epub3/src/main/resources/xml/epub3-to-epub3.xpl
@@ -142,7 +142,7 @@ the navigation document.</p>
         </p:documentation>
     </p:option>
 
-    <p:option name="braille" required="false" px:type="boolean" select="'true'">
+    <p:option name="braille" required="false" px:type="boolean" select="'false'">
         <p:documentation xmlns="http://www.w3.org/1999/xhtml">
             <h2 px:role="name">Translate to braille</h2>
             <p px:role="desc">Whether to produce a braille rendition.</p>


### PR DESCRIPTION
Hi @bertfrees 

From the discussion, we had yesterday the braille conversion should not be default for the epub3 enhancement. So I was told to make a PR to both repositories so this change doesn't make a divergence for the MTM branch.

Best regards
Daniel